### PR TITLE
Update Companies.tsx

### DIFF
--- a/src/components/Companies.tsx
+++ b/src/components/Companies.tsx
@@ -65,12 +65,12 @@ const Companies = (): JSX.Element => {
         placeholder="blurred"
         height={150}
       />
-      <StaticImage
+      {/*<StaticImage
         src="https://brand.sdsu.edu/primary-logos/SDSUprimary3Crgb.jpg"
         alt="San Diego State University"
         placeholder="blurred"
         height={150}
-      />
+      />*/}
     </Marquee>
   );
 };


### PR DESCRIPTION
image source on line 69 (https://brand.sdsu.edu/primary-logos/SDSUprimary3Crgb.jpg) returns 404 error
this causes `yarn develop` to fail

do we have a replacement image?
proposing commenting out for now as a quick fix

error output:
(node:2887) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
(Use `node --trace-deprecation ...` to show where the warning was created)

Failed to validate error [Error [ValidationError]: "error" must be of type object] {
  _original: {
    context: {
      sourceMessage: 'Error loading image https://brand.sdsu.edu/primary-logos/SDSUprimary3Crgb.jpg undefined'
    },
    error: 'failed to process https://brand.sdsu.edu/primary-logos/SDSUprimary3Crgb.jpg\n' +
      'HTTPError: Response code 404 (Not Found)',
    pluginName: 'gatsby-plugin-image',
    text: 'Error loading image https://brand.sdsu.edu/primary-logos/SDSUprimary3Crgb.jpg undefined',
    level: 'ERROR',
    stack: [],
    docsUrl: 'https://gatsby.dev/issue-how-to'
  },
  details: [
    {
      message: '"error" must be of type object',
      path: [Array],
      type: 'object.base',
      context: [Object]
    }
  ]
}